### PR TITLE
FIPS 140 Compliant

### DIFF
--- a/Source/Windows API CodePack/Shell/Common/ShellObject.cs
+++ b/Source/Windows API CodePack/Shell/Common/ShellObject.cs
@@ -437,7 +437,7 @@ namespace Microsoft.WindowsAPICodePack.Shell
             }
             return _hashValue.Value;
         }
-        private static readonly MD5CryptoServiceProvider HashProvider = new();
+        private static readonly SHA256CryptoServiceProvider HashProvider = new();
         private int? _hashValue;
 
         /// <summary>


### PR DESCRIPTION
Update `MD5` to `SHA256` or `SHA512` so the class is FIPS 140 compliant. See [Microsoft's documentation](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.md5cryptoserviceprovider?view=netframework-4.6.2#remarks) about the recommended update.

---
When FIPS compliance is enabled, i.e.
```
[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy]
"Enabled"=dword:00000001
```
an exception is thrown:
```
System.InvalidOperationException
  HResult=0x80131509
  Message=This implementation is not part of the Windows Platform FIPS validated cryptographic algorithms.
  Source=mscorlib
  StackTrace:
   at System.Security.Cryptography.MD5CryptoServiceProvider..ctor()
   at Microsoft.WindowsAPICodePack.Shell.ShellObject..cctor() in Windows-API-CodePack-NET\Source\Windows API CodePack\Shell\Common\ShellObject.cs:line 455
```