### PR TITLE
Fix condition to check HResult in SetEventInterest

### DIFF
--- a/Source/Current/Windows API CodePack/Components/Sensors/ObjectModel/Sensor.cs
+++ b/Source/Current/Windows API CodePack/Components/Sensors/ObjectModel/Sensor.cs
@@ -696,7 +696,7 @@ public class Sensor : ISensorEvents
         newEventInterest[interestCount] = eventType;
 
         HResult hr = _nativeISensor.SetEventInterest(newEventInterest, (uint)(interestCount + 1));
-        if (hr != HResult.Ok || hr != null)
+        if (hr != HResult.Ok)
         {
             throw Marshal.GetExceptionForHR((int)hr);
         }


### PR DESCRIPTION
Fixes https://github.com/PWagner1/Windows-API-CodePack-NET/issues/46

## Summary

Fixes a regression in `Sensor.SetEventInterest` introduced after `7.0.3`.

The current condition checks:

```csharp
if (hr != HResult.Ok || hr != null)
```

Because `HResult` is a non-nullable value type, `hr != null` is always true. This causes the method to enter the error branch even when `_nativeISensor.SetEventInterest(...)` returns `HResult.Ok`.

When the HRESULT is `S_OK` / `0`, `Marshal.GetExceptionForHR((int)hr)` can return `null`, which results in a `NullReferenceException` during sensor enumeration.

## Change

Restores the previous success check:

```csharp
if (hr != HResult.Ok)
```

## Repro

A `net8.0-windows` console app using `WindowsAPICodePackSensors` fails when enumerating ambient light sensors:

```csharp
var sensors = SensorManager.GetSensorsByTypeId<AmbientLightSensor>();
```

Stack trace:

```text
System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.WindowsAPICodePack.Sensors.Sensor.SetEventInterest(Guid eventType)
   at Microsoft.WindowsAPICodePack.Sensors.Sensor.set_InternalObject(ISensor value)
   at Microsoft.WindowsAPICodePack.Sensors.SensorManager.GetSensorWrapperInstance[TS](ISensor nativeISensor)
   at Microsoft.WindowsAPICodePack.Sensors.SensorManager.GetSensorsByTypeId[T]()
```

## Validation

Tested against a Windows machine with an ambient light sensor. `7.0.3` works, while `7.0.4` and later fail with the stack trace above.

This change restores the intended behavior by only throwing when the HRESULT is not `HResult.Ok`.
